### PR TITLE
Move stream descriptor creation into sample providers

### DIFF
--- a/FFmpegInterop/Source/CompressedSampleProvider.cpp
+++ b/FFmpegInterop/Source/CompressedSampleProvider.cpp
@@ -8,8 +8,23 @@ CompressedSampleProvider::CompressedSampleProvider(
 	FFmpegReader^ reader,
 	AVFormatContext* avFormatCtx,
 	AVCodecContext* avCodecCtx,
-	FFmpegInteropConfig^ config, 
-	int streamIndex) : MediaSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex)
+	FFmpegInteropConfig^ config,
+	int streamIndex,
+	VideoEncodingProperties^ encodingProperties) :
+	MediaSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex),
+	videoEncodingProperties(encodingProperties)
+{
+}
+
+CompressedSampleProvider::CompressedSampleProvider(
+	FFmpegReader^ reader,
+	AVFormatContext* avFormatCtx,
+	AVCodecContext* avCodecCtx,
+	FFmpegInteropConfig^ config,
+	int streamIndex,
+	AudioEncodingProperties^ encodingProperties) :
+	MediaSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex),
+	audioEncodingProperties(encodingProperties)
 {
 }
 
@@ -49,4 +64,19 @@ HRESULT CompressedSampleProvider::CreateBufferFromPacket(AVPacket* avPacket, IBu
 	}
 
 	return hr;
+}
+
+IMediaStreamDescriptor^ CompressedSampleProvider::CreateStreamDescriptor()
+{
+	IMediaStreamDescriptor^ mediaStreamDescriptor;
+	if (videoEncodingProperties != nullptr)
+	{
+		SetCommonVideoEncodingProperties(videoEncodingProperties, true);
+		mediaStreamDescriptor = ref new VideoStreamDescriptor(videoEncodingProperties);
+	}
+	else
+	{
+		mediaStreamDescriptor = ref new AudioStreamDescriptor(audioEncodingProperties);
+	}
+	return mediaStreamDescriptor;
 }

--- a/FFmpegInterop/Source/CompressedSampleProvider.h
+++ b/FFmpegInterop/Source/CompressedSampleProvider.h
@@ -10,8 +10,14 @@ namespace FFmpegInterop
 		virtual ~CompressedSampleProvider();
 
 	internal:
-		CompressedSampleProvider(FFmpegReader^ reader, AVFormatContext* avFormatCtx, AVCodecContext* avCodecCtx, FFmpegInteropConfig^ config, int streamIndex);
+		CompressedSampleProvider(FFmpegReader^ reader, AVFormatContext* avFormatCtx, AVCodecContext* avCodecCtx, FFmpegInteropConfig^ config, int streamIndex, VideoEncodingProperties^ encodingProperties);
+		CompressedSampleProvider(FFmpegReader^ reader, AVFormatContext* avFormatCtx, AVCodecContext* avCodecCtx, FFmpegInteropConfig^ config, int streamIndex, AudioEncodingProperties^ encodingProperties);
 		virtual HRESULT CreateNextSampleBuffer(IBuffer^* pBuffer, int64_t& samplePts, int64_t& sampleDuration) override;
 		virtual HRESULT CreateBufferFromPacket(AVPacket* avPacket, IBuffer^* pBuffer);
+		virtual IMediaStreamDescriptor^ CreateStreamDescriptor() override;
+
+	private:
+		VideoEncodingProperties^ videoEncodingProperties;
+		AudioEncodingProperties^ audioEncodingProperties;
 	};
 }

--- a/FFmpegInterop/Source/FFmpegInteropMSS.h
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.h
@@ -144,8 +144,6 @@ namespace FFmpegInterop
 		int videoStreamIndex;
 		int thumbnailStreamIndex;
 
-		bool rotateVideo;
-		int rotationAngle;
 		std::recursive_mutex mutexGuard;
 
 		MediaSampleProvider^ audioSampleProvider;

--- a/FFmpegInterop/Source/H264AVCSampleProvider.cpp
+++ b/FFmpegInterop/Source/H264AVCSampleProvider.cpp
@@ -26,8 +26,9 @@ H264AVCSampleProvider::H264AVCSampleProvider(
 	AVFormatContext* avFormatCtx,
 	AVCodecContext* avCodecCtx,
 	FFmpegInteropConfig^ config,
-	int streamIndex)
-	: NALPacketSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex)
+	int streamIndex,
+	VideoEncodingProperties^ encodingProperties)
+	: NALPacketSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex, encodingProperties)
 {
 }
 

--- a/FFmpegInterop/Source/H264AVCSampleProvider.h
+++ b/FFmpegInterop/Source/H264AVCSampleProvider.h
@@ -33,7 +33,8 @@ namespace FFmpegInterop
 			AVFormatContext* avFormatCtx,
 			AVCodecContext* avCodecCtx,
 			FFmpegInteropConfig^ config, 
-			int streamIndex);
+			int streamIndex,
+			VideoEncodingProperties^ encodingProperties);
 		virtual HRESULT GetSPSAndPPSBuffer(DataWriter^ dataWriter, byte* buf, int length) override;
 		virtual HRESULT WriteNALPacket(AVPacket* avPacket, IBuffer^* pBuffer) override;
 		virtual HRESULT WriteNALPacketAfterExtradata(AVPacket* avPacket, DataWriter^ dataWriter) override;

--- a/FFmpegInterop/Source/HEVCSampleProvider.cpp
+++ b/FFmpegInterop/Source/HEVCSampleProvider.cpp
@@ -26,8 +26,9 @@ HEVCSampleProvider::HEVCSampleProvider(
 	AVFormatContext* avFormatCtx,
 	AVCodecContext* avCodecCtx,
 	FFmpegInteropConfig^ config,
-	int streamIndex)
-	: H264AVCSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex)
+	int streamIndex,
+	VideoEncodingProperties^ encodingProperties)
+	: H264AVCSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex, encodingProperties)
 {
 }
 

--- a/FFmpegInterop/Source/HEVCSampleProvider.h
+++ b/FFmpegInterop/Source/HEVCSampleProvider.h
@@ -33,7 +33,8 @@ namespace FFmpegInterop
 			AVFormatContext* avFormatCtx,
 			AVCodecContext* avCodecCtx,
 			FFmpegInteropConfig^ config, 
-			int streamIndex);
+			int streamIndex,
+			VideoEncodingProperties^ encodingProperties);
 		virtual HRESULT GetSPSAndPPSBuffer(DataWriter^ dataWriter, byte* buf, int length) override;
 	};
 }

--- a/FFmpegInterop/Source/MediaSampleProvider.h
+++ b/FFmpegInterop/Source/MediaSampleProvider.h
@@ -80,6 +80,7 @@ namespace FFmpegInterop
 		FFmpegReader^ m_pReader;
 		AVFormatContext* m_pAvFormatCtx;
 		AVCodecContext* m_pAvCodecCtx;
+		AVStream* m_pAvStream;
 		bool m_isEnabled;
 		bool m_isDiscontinuous;
 		int m_streamIndex;

--- a/FFmpegInterop/Source/NALPacketSampleProvider.cpp
+++ b/FFmpegInterop/Source/NALPacketSampleProvider.cpp
@@ -26,8 +26,9 @@ NALPacketSampleProvider::NALPacketSampleProvider(
 	AVFormatContext* avFormatCtx,
 	AVCodecContext* avCodecCtx,
 	FFmpegInteropConfig^ config,
-	int streamIndex)
-	: CompressedSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex)
+	int streamIndex,
+	VideoEncodingProperties^ encodingProperties)
+	: CompressedSampleProvider(reader, avFormatCtx, avCodecCtx, config, streamIndex, encodingProperties)
 {
 }
 

--- a/FFmpegInterop/Source/NALPacketSampleProvider.h
+++ b/FFmpegInterop/Source/NALPacketSampleProvider.h
@@ -33,7 +33,8 @@ namespace FFmpegInterop
 			AVFormatContext* avFormatCtx,
 			AVCodecContext* avCodecCtx,
 			FFmpegInteropConfig^ config, 
-			int streamIndex);
+			int streamIndex,
+			VideoEncodingProperties^ encodingProperties);
 		virtual HRESULT CreateBufferFromPacket(AVPacket* avPacket, IBuffer^* pBuffer) override;
 		virtual HRESULT GetSPSAndPPSBuffer(DataWriter^ dataWriter, byte* buf, int length);
 		virtual HRESULT WriteNALPacket(AVPacket* avPacket, IBuffer^* pBuffer);

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.cpp
@@ -203,15 +203,15 @@ HRESULT UncompressedAudioSampleProvider::CreateBufferFromFrame(IBuffer^* pBuffer
 	if (SUCCEEDED(hr))
 	{
 		// always update duration with real decoded sample duration
-		auto actualDuration = (long long)avFrame->nb_samples * m_pAvFormatCtx->streams[m_streamIndex]->time_base.den / (outSampleRate * m_pAvFormatCtx->streams[m_streamIndex]->time_base.num);
+		auto actualDuration = (long long)avFrame->nb_samples * m_pAvStream->time_base.den / (outSampleRate * m_pAvStream->time_base.num);
 
 		if (frameDuration != actualDuration)
 		{
 			// compensate for start encoder padding (gapless playback)
-			if (m_pAvFormatCtx->streams[m_streamIndex]->nb_decoded_frames == 1 && m_pAvFormatCtx->streams[m_streamIndex]->start_skip_samples > 0)
+			if (m_pAvStream->nb_decoded_frames == 1 && m_pAvStream->start_skip_samples > 0)
 			{
 				// check if duration difference matches encoder padding
-				auto skipDuration = (long long)m_pAvFormatCtx->streams[m_streamIndex]->start_skip_samples * m_pAvFormatCtx->streams[m_streamIndex]->time_base.den / (outSampleRate * m_pAvFormatCtx->streams[m_streamIndex]->time_base.num);
+				auto skipDuration = (long long)m_pAvStream->start_skip_samples * m_pAvStream->time_base.den / (outSampleRate * m_pAvStream->time_base.num);
 				if (skipDuration == frameDuration - actualDuration)
 				{
 					framePts += skipDuration;

--- a/FFmpegInterop/Source/UncompressedAudioSampleProvider.h
+++ b/FFmpegInterop/Source/UncompressedAudioSampleProvider.h
@@ -39,7 +39,7 @@ namespace FFmpegInterop
 			FFmpegInteropConfig^ config, 
 			int streamIndex);
 		virtual HRESULT CreateBufferFromFrame(IBuffer^* pBuffer, AVFrame* avFrame, int64_t& framePts, int64_t& frameDuration) override;
-		virtual HRESULT AllocateResources() override;
+		IMediaStreamDescriptor^ CreateStreamDescriptor() override;
 		HRESULT CheckFormatChanged(AVFrame* inputFrame);
 		HRESULT UpdateResampler();
 	

--- a/FFmpegInterop/Source/UncompressedVideoSampleProvider.h
+++ b/FFmpegInterop/Source/UncompressedVideoSampleProvider.h
@@ -32,9 +32,6 @@ namespace FFmpegInterop
 	{
 	public:
 		virtual ~UncompressedVideoSampleProvider();
-		property String^ OutputMediaSubtype;
-		property int DecoderWidth;
-		property int DecoderHeight;
 
 	internal:
 		UncompressedVideoSampleProvider(
@@ -43,15 +40,21 @@ namespace FFmpegInterop
 			AVCodecContext* avCodecCtx,
 			FFmpegInteropConfig^ config, 
 			int streamIndex);
+		IMediaStreamDescriptor^ CreateStreamDescriptor() override;
 		virtual HRESULT CreateBufferFromFrame(IBuffer^* pBuffer, AVFrame* avFrame, int64_t& framePts, int64_t& frameDuration) override;
 		virtual HRESULT SetSampleProperties(MediaStreamSample^ sample) override;
 		AVPixelFormat GetOutputPixelFormat() { return m_OutputPixelFormat; }
 
 	private:
+		void SelectOutputFormat();
 		HRESULT InitializeScalerIfRequired();
 		HRESULT FillLinesAndBuffer(int* linesize, byte** data, AVBufferRef** buffer);
 		AVBufferRef* AllocateBuffer(int totalSize);
 		static int get_buffer2(AVCodecContext *avCodecContext, AVFrame *frame, int flags);
+
+		String^ outputMediaSubtype;
+		int decoderWidth;
+		int decoderHeight;
 
 		AVBufferPool *m_pBufferPool;
 		AVPixelFormat m_OutputPixelFormat;


### PR DESCRIPTION
This is a first step to support multiple audio streams. Each sample provider has its own stream descriptor. The idea is that later ffmpeginterop only has a list of sample providers and picks the right one based on stream descriptor. No more fixed video or audio sample provider.

Also, sample providers are now responsible for creating their stream descriptors. This avoids duplicate parameter parsing and simplifies the main class.