### PR TITLE
Add VS2017 build file

### DIFF
--- a/BuildFFmpeg_VS2017.bat
+++ b/BuildFFmpeg_VS2017.bat
@@ -1,0 +1,116 @@
+@setlocal
+@echo off
+
+rem Set the Windows SDK version
+set WindowsSDKversion=10.0.16299.0
+
+echo:
+echo Searching VS Installation folder...
+
+set VSInstallerFolder="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer"
+if %PROCESSOR_ARCHITECTURE%==x86 set VSInstallerFolder="%ProgramFiles%\Microsoft Visual Studio\Installer"
+
+pushd %VSInstallerFolder%
+for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+  set VSLATESTDIR=%%i
+)
+popd
+
+echo VS Installation folder: %VSLATESTDIR%
+
+if not exist "%VSLATESTDIR%\VC\Auxiliary\Build\vcvarsall.bat" (
+    echo:
+    echo VSInstallDir not found or not installed correctly.
+    goto Cleanup
+)
+
+echo:
+echo Checking CPU architecture...
+
+if %PROCESSOR_ARCHITECTURE%==x86 (
+    set Comp_x86=x86
+    set Comp_x64=x86_amd64
+    set Comp_ARM=x86_arm
+) else (
+    set Comp_x86=amd64_x86
+    set Comp_x64=amd64
+    set Comp_ARM=amd64_arm
+)
+
+:: Export full current PATH from environment into MSYS2
+set MSYS2_PATH_TYPE=inherit
+
+:: Verifying ffmpeg directory
+echo Verifying ffmpeg directory...
+pushd %~dp0\ffmpeg
+if not exist configure (
+    echo:
+    echo configure is not found in ffmpeg folder. Ensure this folder is populated with ffmpeg snapshot
+    goto Cleanup
+)
+popd
+
+:: Check for required tools
+
+echo:
+echo Checking for MSYS2...
+
+if not defined MSYS2_BIN (
+    if exist C:\msys64\usr\bin\bash.exe set MSYS2_BIN="C:\msys64\usr\bin\bash.exe"
+)
+
+if not defined MSYS2_BIN (
+    if exist C:\msys\usr\bin\bash.exe set MSYS2_BIN="C:\msys\usr\bin\bash.exe"
+)
+
+if defined MSYS2_BIN (
+    if exist %MSYS2_BIN% goto Win10
+)
+
+echo:
+echo MSYS2 is needed. Set it up properly and provide the executable path in MSYS2_BIN environment variable. E.g.
+echo:
+echo     set MSYS2_BIN="C:\msys64\usr\bin\bash.exe"
+echo:
+echo See https://trac.ffmpeg.org/wiki/CompilationGuide/WinRT#PrerequisitesandFirstTimeSetupInstructions
+goto Cleanup
+
+:: Build and deploy Windows 10 library
+:Win10
+
+
+:Win10x86
+echo Building FFmpeg for Windows 10 apps x86...
+echo:
+
+setlocal
+call "%VSLATESTDIR%\VC\Auxiliary\Build\vcvarsall.bat" %Comp_x86%
+
+%MSYS2_BIN% --login -x %~dp0FFmpegConfig.sh Win10 x86
+for /r %~dp0\ffmpeg\Output\Windows10\x86 %%f in (*.pdb) do @copy "%%f" %~dp0\ffmpeg\Build\Windows10\x86\bin
+endlocal
+
+:Win10x64
+echo Building FFmpeg for Windows 10 apps x64...
+echo:
+
+setlocal
+call "%VSLATESTDIR%\VC\Auxiliary\Build\vcvarsall.bat" %Comp_x64%
+
+%MSYS2_BIN% --login -x %~dp0FFmpegConfig.sh Win10 x64
+for /r %~dp0\ffmpeg\Output\Windows10\x64 %%f in (*.pdb) do @copy "%%f" %~dp0\ffmpeg\Build\Windows10\x64\bin
+endlocal
+
+:Win10ARM
+echo Building FFmpeg for Windows 10 apps ARM...
+echo:
+
+setlocal
+call "%VSLATESTDIR%\VC\Auxiliary\Build\vcvarsall.bat" %Comp_ARM%
+
+%MSYS2_BIN% --login -x %~dp0FFmpegConfig.sh Win10 ARM
+for /r %~dp0\ffmpeg\Output\Windows10\ARM %%f in (*.pdb) do @copy "%%f" %~dp0\ffmpeg\Build\Windows10\ARM\bin
+endlocal
+
+:Cleanup
+@endlocal

--- a/FFmpegConfig.sh
+++ b/FFmpegConfig.sh
@@ -15,13 +15,16 @@ if [ "$1" == "Win10" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=x86 \
         --enable-shared \
         --enable-cross-compile \
+        --enable-debug \
         --target-os=win32 \
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00" \
         --extra-ldflags="-APPCONTAINER WindowsApp.lib" \
         --prefix=../../../Build/Windows10/x86
+        make -j8
         make install
         popd
 
@@ -36,13 +39,16 @@ if [ "$1" == "Win10" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=x86_64 \
         --enable-shared \
         --enable-cross-compile \
+        --enable-debug \
         --target-os=win32 \
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00" \
         --extra-ldflags="-APPCONTAINER WindowsApp.lib" \
         --prefix=../../../Build/Windows10/x64
+        make -j8
         make install
         popd
 
@@ -57,16 +63,19 @@ if [ "$1" == "Win10" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=arm \
         --as=armasm \
         --cpu=armv7 \
         --enable-thumb \
         --enable-shared \
         --enable-cross-compile \
+        --enable-debug \
         --target-os=win32 \
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00 -D__ARM_PCS_VFP" \
         --extra-ldflags="-APPCONTAINER WindowsApp.lib" \
         --prefix=../../../Build/Windows10/ARM
+        make -j8
         make install
         popd
 
@@ -86,9 +95,11 @@ elif [ "$1" == "Win8.1" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=x86 \
         --enable-shared \
         --enable-cross-compile \
+        --enable-debug \
         --target-os=win32 \
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP -D_WIN32_WINNT=0x0603" \
         --extra-ldflags="-APPCONTAINER" \
@@ -107,9 +118,11 @@ elif [ "$1" == "Win8.1" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=x86_64 \
         --enable-shared \
         --enable-cross-compile \
+        --enable-debug \
         --target-os=win32 \
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP -D_WIN32_WINNT=0x0603" \
         --extra-ldflags="-APPCONTAINER" \
@@ -128,12 +141,14 @@ elif [ "$1" == "Win8.1" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=arm \
         --as=armasm \
         --cpu=armv7 \
         --enable-thumb \
         --enable-shared \
         --enable-cross-compile \
+        --enable-debug \
         --target-os=win32 \
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP -D_WIN32_WINNT=0x0603 -D__ARM_PCS_VFP" \
         --extra-ldflags="-APPCONTAINER -MACHINE:ARM" \
@@ -157,12 +172,14 @@ elif [ "$1" == "Phone8.1" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=arm \
         --as=armasm \
         --cpu=armv7 \
         --enable-thumb \
         --enable-shared \
         --enable-cross-compile \
+        --enable-debug \
         --target-os=win32 \
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP -D_WIN32_WINNT=0x0603 -D__ARM_PCS_VFP" \
         --extra-ldflags="-APPCONTAINER -MACHINE:ARM -subsystem:console -opt:ref WindowsPhoneCore.lib RuntimeObject.lib PhoneAppModelHost.lib -NODEFAULTLIB:kernel32.lib -NODEFAULTLIB:ole32.lib" \
@@ -181,10 +198,12 @@ elif [ "$1" == "Phone8.1" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=x86 \
         --enable-shared \
         --enable-cross-compile \
         --target-os=win32 \
+        --enable-debug \
         --extra-cflags="-MD -DWINAPI_FAMILY=WINAPI_FAMILY_PHONE_APP -D_WIN32_WINNT=0x0603" \
         --extra-ldflags="-APPCONTAINER -subsystem:console -opt:ref WindowsPhoneCore.lib RuntimeObject.lib PhoneAppModelHost.lib -NODEFAULTLIB:kernel32.lib -NODEFAULTLIB:ole32.lib" \
         --prefix=../../../Build/WindowsPhone8.1/x86
@@ -207,9 +226,11 @@ elif [ "$1" == "Win7" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=x86 \
         --enable-shared \
         --enable-cross-compile \
+        --enable-debug \
         --target-os=win32 \
         --extra-cflags="-MD -D_WINDLL" \
         --extra-ldflags="-APPCONTAINER:NO -MACHINE:x86" \
@@ -228,9 +249,11 @@ elif [ "$1" == "Win7" ]; then
         --disable-programs \
         --disable-d3d11va \
         --disable-dxva2 \
+        --disable-doc \
         --arch=amd64 \
         --enable-shared \
         --enable-cross-compile \
+        --enable-debug \
         --target-os=win32 \
         --extra-cflags="-MD -D_WINDLL" \
         --extra-ldflags="-APPCONTAINER:NO -MACHINE:x64" \


### PR DESCRIPTION
I created a build file that works with VS2017. It does not require any parameter and builds all three Windows 10 platforms. I also done some enhancements: Parallel ffmpeg build to speed up things a bit, plus pdb creation so we can debug into ffmpeg if there is a need for it. I also removed doxygen build.

Now there is no need anymore to install whooping 26GB VS2015 just to build ffmpeg. But you still need to install all dependencies such as MSYS2, as described on ffmpeg site. It is not an automatic solution like what @khouzam prepared.