### PR TITLE
Fix broken video after switch streams

### DIFF
--- a/FFmpegInterop/Source/NALPacketSampleProvider.cpp
+++ b/FFmpegInterop/Source/NALPacketSampleProvider.cpp
@@ -36,6 +36,12 @@ NALPacketSampleProvider::~NALPacketSampleProvider()
 {
 }
 
+void NALPacketSampleProvider::Flush()
+{
+	CompressedSampleProvider::Flush();
+	m_bHasSentExtradata = false;
+}
+
 HRESULT NALPacketSampleProvider::CreateBufferFromPacket(AVPacket* avPacket, IBuffer^* pBuffer)
 {
 	HRESULT hr = S_OK;

--- a/FFmpegInterop/Source/NALPacketSampleProvider.h
+++ b/FFmpegInterop/Source/NALPacketSampleProvider.h
@@ -26,6 +26,7 @@ namespace FFmpegInterop
 	{
 	public:
 		virtual ~NALPacketSampleProvider();
+		virtual void Flush() override;
 
 	internal:
 		NALPacketSampleProvider(


### PR DESCRIPTION
This should fix #22 by sending extradata again after a flush of compressed video streams. I cannot explain why it is neccessary, it does not really make sense. Probably something else is happening when switching streams in MF or MSS, which causes the MF video decoder to re-initialize or something like that.