### PR TITLE
correct start_time check

### DIFF
--- a/FFmpegInterop/Source/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/Source/FFmpegInteropMSS.cpp
@@ -1184,7 +1184,15 @@ HRESULT FFmpegInteropMSS::Seek(TimeSpan position)
 	if (streamIndex >= 0)
 	{
 		// Compensate for file start_time, then convert to stream time_base
-		auto correctedPosition = position.Duration + (avFormatCtx->start_time * 10);
+		int64 correctedPosition;
+		if (avFormatCtx->start_time == AV_NOPTS_VALUE)
+		{
+			correctedPosition = 0;
+		}
+		else
+		{
+			correctedPosition = position.Duration + (avFormatCtx->start_time * 10);
+		}
 		int64_t seekTarget = static_cast<int64_t>(correctedPosition / (av_q2d(avFormatCtx->streams[streamIndex]->time_base) * 10000000));
 
 		if (av_seek_frame(avFormatCtx, streamIndex, seekTarget, AVSEEK_FLAG_BACKWARD) < 0)

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -39,7 +39,7 @@ MediaSampleProvider::MediaSampleProvider(
 	, m_streamIndex(streamIndex)
 {
 	DebugMessage(L"MediaSampleProvider\n");
-	if (m_pAvFormatCtx->start_time != 0)
+	if (m_pAvFormatCtx->start_time != AV_NOPTS_VALUE)
 	{
 		auto streamStartTime = (long long)(av_q2d(m_pAvStream->time_base) * m_pAvStream->start_time * 1000000);
 

--- a/FFmpegInterop/Source/MediaSampleProvider.cpp
+++ b/FFmpegInterop/Source/MediaSampleProvider.cpp
@@ -55,7 +55,16 @@ MediaSampleProvider::MediaSampleProvider(
 	}
 
 	// init first packet pts time from start_time
-	m_nextPacketPts = m_pAvFormatCtx->streams[m_streamIndex]->start_time;
+	if (m_pAvFormatCtx->streams[m_streamIndex]->start_time == AV_NOPTS_VALUE)
+	{
+		//if start time is AV_NOPTS_VALUE, set it to 0
+		m_nextPacketPts = 0;
+	}
+	else 
+	{
+		//otherwise set the start time of the first packet to the stream start time.
+		m_nextPacketPts = m_pAvFormatCtx->streams[m_streamIndex]->start_time;
+	}
 }
 
 MediaSampleProvider::~MediaSampleProvider()


### PR DESCRIPTION
AVFormatContex start_time has value AV_NOPTS_VALUE when not set. It is possible that some files come up with if AV_NOPTS_VALUE as start time (negative, but different than 0), thus resulting in weird presentation time stamps.

This simple PR fixes that.

