### PR TITLE
Fix frame rate issue

### DIFF
--- a/FFmpegInterop/Source/NALPacketSampleProvider.h
+++ b/FFmpegInterop/Source/NALPacketSampleProvider.h
@@ -40,8 +40,12 @@ namespace FFmpegInterop
 		virtual HRESULT GetSPSAndPPSBuffer(DataWriter^ dataWriter, byte* buf, int length);
 		virtual HRESULT WriteNALPacket(AVPacket* avPacket, IBuffer^* pBuffer);
 		virtual HRESULT WriteNALPacketAfterExtradata(AVPacket* avPacket, DataWriter^ dataWriter);
+		virtual void SetCommonVideoEncodingProperties(VideoEncodingProperties^ videoEncodingProperties, bool isCompressedFormat) override;
 
 	private:
-		bool m_bHasSentExtradata;
+		HRESULT CreateExtradataFromPacket(AVPacket* avPacket);
+		IBuffer^ extradata;
+		bool hasSentExtradata;
+		bool repeatExtradata;
 	};
 }


### PR DESCRIPTION
This fixes #62 by sending codec extradata repeatedly if no frame rate is found for a video stream. Optimizations are included to only parse extradata once and only repeat it if no frame rate is found.