### PR TITLE
Check that decoder has a valid output format

### DIFF
--- a/FFmpegInterop/FFmpegInteropMSS.cpp
+++ b/FFmpegInterop/FFmpegInteropMSS.cpp
@@ -819,6 +819,10 @@ MediaSampleProvider^ FFmpegInteropMSS::CreateAudioStream(AVStream * avStream, in
 				{
 					hr = E_FAIL;
 				}
+				else if (avAudioCodecCtx->sample_fmt == AV_SAMPLE_FMT_NONE)
+				{
+					hr = E_FAIL;
+				}
 				else
 				{
 					// Detect audio format and create audio stream descriptor accordingly
@@ -881,6 +885,10 @@ MediaSampleProvider^ FFmpegInteropMSS::CreateVideoStream(AVStream * avStream, in
 			}
 
 			if (avcodec_open2(avVideoCodecCtx, avVideoCodec, NULL) < 0)
+			{
+				hr = E_FAIL;
+			}
+			else if (avVideoCodecCtx->pix_fmt == AV_PIX_FMT_NONE)
 			{
 				hr = E_FAIL;
 			}


### PR DESCRIPTION
This is to fix the issue reported in MS repo:

https://github.com/Microsoft/FFmpegInterop/issues/256

I added the check for both video and audio decoders.